### PR TITLE
Get shopcart

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
     "cSpell.words": [
-        "sqlalchemy",
         "psycopg",
+        "shopcart",
+        "shopcarts",
+        "sqlalchemy",
         "testdb"
     ]
 }

--- a/service/routes.py
+++ b/service/routes.py
@@ -42,6 +42,7 @@ def index():
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################
 
+
 ######################################################################
 # CREATE A NEW SHOPCART
 ######################################################################
@@ -68,6 +69,34 @@ def create_shopcarts():
 
 
 ######################################################################
+# READ A SHOPCART
+######################################################################
+@app.route("/shopcarts/<int:shopcart_id>", methods=["GET"])
+def get_shopcarts(shopcart_id):
+    """
+    Retrieve a single Shopcart
+
+    This endpoint will return a Shopcart based on it's id
+    """
+    app.logger.info("Request for shopcart with id: %s", shopcart_id)
+
+    shopcart = Shopcart.find(shopcart_id)
+    if not shopcart:
+        error(
+            status.HTTP_404_NOT_FOUND,
+            f"Shopcart with id '{shopcart_id}' was not found.",
+        )
+
+    app.logger.info("Returning shopcart for the user with an id: %s", shopcart.user_id)
+    return jsonify(shopcart.serialize()), status.HTTP_200_OK
+
+
+######################################################################
+#  U T I L I T Y   F U N C T I O N S
+######################################################################
+
+
+######################################################################
 # Checks the ContentType of a request
 ######################################################################
 def check_content_type(content_type):
@@ -87,6 +116,7 @@ def check_content_type(content_type):
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
         f"Content-Type must be {content_type}",
     )
+
 
 ######################################################################
 # Logs error messages before aborting


### PR DESCRIPTION
With this PR, I have created the `get-shopcart` endpoint to get a single shopping cart using the following URL: GET`/shopcarts/<int:shopcart_id>`

```python
---------- coverage: platform linux, python 3.11.8-final-0 -----------
Name                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------
service/__init__.py                    23      2    91%   50-51
service/common/__init__.py              0      0   100%
service/common/cli_commands.py          8      0   100%
service/common/error_handlers.py       33     13    61%   31, 37-39, 61-63, 76-78, 91-93
service/common/log_handlers.py         11      1    91%   35
service/common/status.py               46      0   100%
service/config.py                       7      0   100%
service/models/__init__.py              3      0   100%
service/models/item.py                 54      5    91%   96, 101-102, 118-119
service/models/persistent_base.py      51      8    84%   41, 73-78, 85
service/models/shopcart.py             72     16    78%   72-75, 99, 114-125, 142-143
service/routes.py                      38      4    89%   105-106, 114-115
-----------------------------------------------------------------
TOTAL                                 346     49    86%

FAIL Required test coverage of 95% not reached. Total coverage: 85.84%

=============================================================== 29 passed in 7.37s ================================================================
```